### PR TITLE
code of conduct

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -4,17 +4,16 @@ EVERYONE CAN LEARN TO CODE … of conduct
 
 ## Test Double's Code of Conduct
 
-Diversity and inclusion make our company strong. We encourage participation
+Diversity and inclusion make our community strong. We encourage participation
 from the most varied and diverse backgrounds possible and want to be very clear
 about where we stand. Our goal is to maintain a safe, helpful, and friendly
-company for everyone, regardless of ability, age, body size, ethnicity,
+community for everyone, regardless of ability, age, body size, ethnicity,
 experience, gender identity and expression, nationality, personal appearance,
 race, religion, sexual orientation, or other characteristic.
 
-This Code of Conduct applies to all one-on-one communications, slack channels,
-retreats and Test Double events, but also to activities outside of that scope,
-online and in person — anywhere such behaviour has the potential to adversely
-affect the safety and well-being of employees.
+This Code of Conduct applies to all community interactions, including (but not
+limited to) one-on-one communications, public posts/comments, code reviews,
+pull requests, and GitHub issues.
 
 ### Expected Behavior
 
@@ -48,6 +47,6 @@ Understand that speech and actions have consequences, and unacceptable behavior 
 
 If you are the subject of or witness to any violations of this Code of Conduct, please contact [Christine McCallum Randalls](mailto:christine@testdouble.com).
 
-If violations occur, Test Double will take any action they deem appropriate for the infraction, up to and including termination of employment.
+If violations occur, Test Double will take any action they deem appropriate for the infraction, up to and including blocking a user from the organization's repositories.
 
 [Primary Code of Conduct](https://testdouble.com/code-of-conduct)

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# CODE OF CONDUCT
+
+EVERYONE CAN LEARN TO CODE … of conduct
+
+## Test Double's Code of Conduct
+
+Diversity and inclusion make our company strong. We encourage participation
+from the most varied and diverse backgrounds possible and want to be very clear
+about where we stand. Our goal is to maintain a safe, helpful, and friendly
+company for everyone, regardless of ability, age, body size, ethnicity,
+experience, gender identity and expression, nationality, personal appearance,
+race, religion, sexual orientation, or other characteristic.
+
+This Code of Conduct applies to all one-on-one communications, slack channels,
+retreats and Test Double events, but also to activities outside of that scope,
+online and in person — anywhere such behaviour has the potential to adversely
+affect the safety and well-being of employees.
+
+### Expected Behavior
+
+* Be respectful.
+* Be welcoming.
+* Be kind.
+* Look out for each other.
+
+### Unacceptable Behavior (online or in person) (non-exhaustive)
+
+* Disrespect towards others. (Jokes, innuendo, dismissive attitudes.)
+* Disrespect towards differences of opinion.
+* Personal insults, including those related to ability, gender, gender identity and expression, sexual orientation, race, or religion.
+* Violence, threats of violence or violent language directed against another person.
+* Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes, language or behavior.
+* Posting or displaying sexually explicit or violent material.
+* Posting or threatening to post other people’s personally identifying information ("doxxing").
+* Inappropriate photography or recording.
+* Inappropriate attention or contact. Be aware of how your actions affect others. If it makes someone uncomfortable, stop.
+* Inappropriate physical contact. You should have someone’s consent before touching them.
+* Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcome sexual advances.
+* Unwelcome, suggestive, derogatory or inappropriate nicknames or terms.
+* Deliberate intimidation, stalking or following (online or in person).
+* Advocating for, or encouraging, any of the above behavior.
+* Sustained disruption of community events, including talks and presentations.
+* Framing disparagement as constructive criticism, and vice versa.
+
+### Enforcement
+
+Understand that speech and actions have consequences, and unacceptable behavior will not be tolerated.
+
+If you are the subject of or witness to any violations of this Code of Conduct, please contact [Christine McCallum Randalls](mailto:christine@testdouble.com).
+
+If violations occur, Test Double will take any action they deem appropriate for the infraction, up to and including termination of employment.
+
+[Primary Code of Conduct](https://testdouble.com/code-of-conduct)


### PR DESCRIPTION
The creation of this repository is to enable a default code of conduct for the entire StandardRB organization. GitHub itself only recognizes codes of conduct when the CODE_OF_CONDUCT file can be found either in the repo itself (root, docs/ or .github/ paths) or in the organizations special .github repo (under root, docs/ or .github/ paths).

Once this PR is merged, the code of conduct in this repo will be linked from all standardrb organization repositories that don't have their own CODE_OF_CONDUCT.

<img width="950" alt="Screenshot 2025-07-04 at 1 11 08 PM" src="https://github.com/user-attachments/assets/663b66c4-60ee-4b28-b771-fb806d18ba35" />



- **Initial import of Test Double code of conduct** from https://testdouble.com/code-of-conduct

- **Modify code of conduct for open source**
  - changed `company` to `community`
  - modified the interactions listed (taken from [standardrb's code of conduct](https://github.com/standardrb/standard?tab=readme-ov-file#code-of-conduct))
  - modified the enforcement (taken from [standardrb's code of conduct](https://github.com/standardrb/standard?tab=readme-ov-file#code-of-conduct))
  - see the actual diff from test double's hosted copy https://github.com/standardrb/.github/pull/1/commits/b91f2efbfc1b13731be817f6c19bc44522794143