### PR TITLE
Create security policy for standardrb organization

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,17 @@
+<!--
+This is a default security policy that applies to the entire standardrb organization.
+It may be overridden by a repo-specific security policy.
+https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file
+-->
+
+# Security Policy
+
+## Supported Versions ✅
+
+Only the greatest published version (according to SemVer) will be supported.
+This version will be indicated as the "Latest Release" on GitHub Releases. :octocat:
+
+## Reporting a Vulnerability ⚠️
+
+Use GitHub's built-in reporting mechanism for disclosure.
+Go to the repository's Security tab -> Advisories -> New draft security advisory.


### PR DESCRIPTION
Applies to the entire standardrb organization because it's a "default community health file". https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

An example of how it would look once this is merged:
![image](https://github.com/user-attachments/assets/3503e7d3-cf41-4a67-9668-8cfa4fa52812)

And it resolves another community health item: 
![image](https://github.com/user-attachments/assets/2157834e-feff-4e2d-8b76-2c5eec38bda2)
